### PR TITLE
Added additional filtering options.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Firebase Configuration
+# Copy this file to .env.local and fill in your Firebase project credentials
+# You can find these values in your Firebase Console under Project Settings > Your apps
+
+NEXT_PUBLIC_FIREBASE_API_KEY=your_api_key_here
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.firebasestorage.app
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
+
+# Instructions:
+# 1. Copy this file: cp .env.example .env.local
+# 2. Fill in your Firebase credentials from Firebase Console
+# 3. For different environments, create .env.development, .env.staging, .env.production
+# 4. Never commit .env.local or any .env file with actual credentials

--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,8 @@
+{
+  "projects": {
+    "default": "staging-dance-up-app",
+    "staging": "staging-dance-up-app",
+    "production": "dance-up-app"
+  }
+}
+

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,12 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
+.env.development
+.env.staging
+.env.production
+!.env.example
 
 # vercel
 .vercel

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -9,54 +9,51 @@ runConfig:
 
 # Environment variables and secrets.
 env:
-  # Configure environment variables for Firebase configuration.
-  # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
+  # Production Firebase Configuration using Cloud Secret Manager
+  # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
+  # 
+  # IMPORTANT: Create these secrets in Google Cloud Secret Manager before deploying
+  # Secret names must match the 'secret' values below
   
-  # Production Firebase Configuration
   - variable: NEXT_PUBLIC_FIREBASE_API_KEY
-    value: AIzaSyBedfrDjaekeYYza_-O1CXbau5HyLqHtck
+    secret: firebase-api-key
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-    value: dance-up-app.firebaseapp.com
+    secret: firebase-auth-domain
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-    value: dance-up-app
+    secret: firebase-project-id
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
-    value: dance-up-app.firebasestorage.app
+    secret: firebase-storage-bucket
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
-    value: "734142219537"
+    secret: firebase-messaging-sender-id
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_APP_ID
-    value: 1:734142219537:web:cb73cf8b9cd1a94687b8b0
+    secret: firebase-app-id
     availability:
       - BUILD
       - RUNTIME
       
   - variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
-    value: G-8BQVRBVQNL
+    secret: firebase-measurement-id
     availability:
       - BUILD
       - RUNTIME
-
-  # Grant access to secrets in Cloud Secret Manager.
-  # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
-  # - variable: MY_SECRET
-  #   secret: mySecretRef
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,0 +1,62 @@
+# Settings for Backend (on Cloud Run).
+# See https://firebase.google.com/docs/app-hosting/configure#cloud-run
+runConfig:
+  minInstances: 0
+  # maxInstances: 100
+  # concurrency: 80
+  # cpu: 1
+  # memoryMiB: 512
+
+# Environment variables and secrets.
+env:
+  # Configure environment variables for Firebase configuration.
+  # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
+  
+  # Production Firebase Configuration
+  - variable: NEXT_PUBLIC_FIREBASE_API_KEY
+    value: AIzaSyBedfrDjaekeYYza_-O1CXbau5HyLqHtck
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    value: dance-up-app.firebaseapp.com
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    value: dance-up-app
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    value: dance-up-app.firebasestorage.app
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    value: "734142219537"
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_APP_ID
+    value: 1:734142219537:web:cb73cf8b9cd1a94687b8b0
+    availability:
+      - BUILD
+      - RUNTIME
+      
+  - variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+    value: G-8BQVRBVQNL
+    availability:
+      - BUILD
+      - RUNTIME
+
+  # Grant access to secrets in Cloud Secret Manager.
+  # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
+  # - variable: MY_SECRET
+  #   secret: mySecretRef
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -112,7 +112,7 @@ export default function Login() {
     facebook: '',
     instagram: '',
     tiktok: '',
-    accessLevel: 'studio_owner',
+    accessLevel: '', // Keep blank for legacy purposes
   });
   const [studioImage, setStudioImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string>('');
@@ -258,14 +258,14 @@ export default function Login() {
           instagram: formData.instagram || '',
           tiktok: formData.tiktok || '',
         },
-        accessLevel: formData.accessLevel,
+        role: 'studio_owner', // Automatically assign studio owner role
+        accessLevel: '', // Keep blank for legacy purposes
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       };
 
-      // Save to both users and studioOwners collections
+      // Save only to users collection
       await setDoc(doc(db, 'users', userCredential.user.uid), userData);
-      await setDoc(doc(db, 'studioOwners', userCredential.user.uid), userData);
 
       // Redirect to dashboard after successful registration
       router.push('/dashboard');

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   Box,
@@ -84,6 +84,7 @@ interface DashboardLayoutProps {
 }
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
+  const [mounted, setMounted] = useState(false);
   const [user] = useAuthState(auth);
   const pathname = usePathname();
   const theme = useTheme();
@@ -91,6 +92,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const router = useRouter();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -250,10 +255,30 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     </Box>
   );
 
+  if (!mounted) {
+    return (
+      <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+        <Box
+          component="main"
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            width: '100%',
+            minHeight: '100vh',
+            backgroundColor: 'background.default',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh' }}>
       {/* Mobile Menu Button - Show only on mobile at top */}
       <Box
+        suppressHydrationWarning
         sx={{
           position: 'fixed',
           top: 0,
@@ -339,6 +364,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           ModalProps={{
             keepMounted: true, // Better open performance on mobile.
           }}
+          suppressHydrationWarning
           sx={{
             display: { xs: 'block', md: 'none' },
             '& .MuiDrawer-paper': {
@@ -353,6 +379,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
         {/* Desktop drawer */}
         <Drawer
           variant="permanent"
+          suppressHydrationWarning
           sx={{
             display: { xs: 'none', md: 'block' },
             '& .MuiDrawer-paper': {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,41 +1,57 @@
-import { initializeApp } from 'firebase/app';
+import { initializeApp, getApps, FirebaseApp } from 'firebase/app';
 import { getAnalytics, isSupported } from 'firebase/analytics';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 import { getFirestore } from 'firebase/firestore';
 
 // Your web app's Firebase configuration from environment variables
+// Fallback to hardcoded staging values if env vars aren't loaded
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY || 'AIzaSyDIi2nkAlIbl3bVulhQxI6KUGdMwunuDMM',
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || 'staging-dance-up-app.firebaseapp.com',
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'staging-dance-up-app',
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || 'staging-dance-up-app.firebasestorage.app',
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '1042260177273',
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID || '1:1042260177273:web:0168e0ad3239708fae7fa8',
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || 'G-YVL8S49FGY'
 };
 
-// Validate required environment variables
-const requiredEnvVars = [
-  'NEXT_PUBLIC_FIREBASE_API_KEY',
-  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
-  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
-  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
-  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
-  'NEXT_PUBLIC_FIREBASE_APP_ID'
-];
-
-const missingVars = requiredEnvVars.filter(varName => !process.env[varName]);
-
-if (missingVars.length > 0) {
-  throw new Error(
-    `Missing required Firebase environment variables: ${missingVars.join(', ')}\n` +
-    'Please check your .env.local file and ensure all Firebase configuration values are set.'
-  );
+// Validate that we have Firebase config values (either from env or fallback)
+function validateFirebaseConfig() {
+  const requiredFields = ['apiKey', 'authDomain', 'projectId', 'storageBucket', 'messagingSenderId', 'appId'];
+  const missingFields = requiredFields.filter(field => !firebaseConfig[field as keyof typeof firebaseConfig]);
+  
+  if (missingFields.length > 0) {
+    console.error('Missing Firebase config fields:', missingFields);
+    return false;
+  }
+  
+  // Log if using fallback values
+  if (!process.env.NEXT_PUBLIC_FIREBASE_API_KEY) {
+    console.warn(
+      '⚠️  Using fallback Firebase configuration values (env vars not loaded).\n' +
+      'Please restart your Next.js dev server to load .env.local file properly.\n' +
+      'The app will work with fallback values for now.'
+    );
+  }
+  
+  return true;
 }
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
+let app: FirebaseApp;
+if (validateFirebaseConfig()) {
+  // Check if Firebase is already initialized
+  const existingApps = getApps();
+  if (existingApps.length === 0) {
+    app = initializeApp(firebaseConfig);
+  } else {
+    app = existingApps[0];
+  }
+} else {
+  // This shouldn't happen with fallback values, but handle it gracefully
+  throw new Error('Firebase configuration is incomplete. Please check your environment variables.');
+}
 
 // Initialize Analytics (only in browser)
 let analytics;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -4,16 +4,35 @@ import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
 import { getFirestore } from 'firebase/firestore';
 
-// Your web app's Firebase configuration
+// Your web app's Firebase configuration from environment variables
 const firebaseConfig = {
-  apiKey: "AIzaSyDIi2nkAlIbl3bVulhQxI6KUGdMwunuDMM",
-  authDomain: "staging-dance-up-app.firebaseapp.com",
-  projectId: "staging-dance-up-app",
-  storageBucket: "staging-dance-up-app.firebasestorage.app",
-  messagingSenderId: "1042260177273",
-  appId: "1:1042260177273:web:0168e0ad3239708fae7fa8",
-  measurementId: "G-YVL8S49FGY"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
 };
+
+// Validate required environment variables
+const requiredEnvVars = [
+  'NEXT_PUBLIC_FIREBASE_API_KEY',
+  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'NEXT_PUBLIC_FIREBASE_APP_ID'
+];
+
+const missingVars = requiredEnvVars.filter(varName => !process.env[varName]);
+
+if (missingVars.length > 0) {
+  throw new Error(
+    `Missing required Firebase environment variables: ${missingVars.join(', ')}\n` +
+    'Please check your .env.local file and ensure all Firebase configuration values are set.'
+  );
+}
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds city/state-based event locations with UI/validation, migrates studio profile management to `users` with public `studios` sync, and switches Firebase to env-driven config with hosting secrets.
> 
> - **Events (`src/app/dashboard/events/page.tsx`)**:
>   - Normalize location to `city`/`state` (keep legacy `location` string for compatibility) and update display/validation.
>   - Edit dialog replaces single location input with `City` + `State` select; derives values from legacy `location` when editing.
>   - Persist normalized fields and computed `location` string.
> - **Studio Profile (`src/app/dashboard/studio/page.tsx`)**:
>   - Fetch/update profile from `users/{uid}` (remove `studioOwners` usage).
>   - On save, upsert public profile in `studios/{uid}` with `city`/`state` and `location` string.
>   - Add dynamic render/mounted guard to prevent hydration issues; minor robustness fixes (email display, imports).
> - **Auth/Sign Up (`src/app/login/page.tsx`)**:
>   - Save profile only to `users/{uid}` with `role: 'studio_owner'` and blank `accessLevel`.
> - **Layout (`src/components/DashboardLayout.tsx`)**:
>   - Add mounted guard and `suppressHydrationWarning` for drawer/menu to avoid hydration mismatches.
> - **Firebase (`src/lib/firebase.ts`)**:
>   - Refactor to read config from `NEXT_PUBLIC_FIREBASE_*` env vars with fallbacks; ensure singleton app init; optional analytics init.
> - **Config/Infra**:
>   - Add `.env.example`, refine `.gitignore` to allow committing the example, add `.firebaserc`.
>   - Add `apphosting.yaml` with Cloud Secret Manager bindings for Firebase env vars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1075d1050795e50d9ad5e5ffcfa791f745cd710. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->